### PR TITLE
Handle 409 response code

### DIFF
--- a/cmd/create_event_async/README.md
+++ b/cmd/create_event_async/README.md
@@ -1,0 +1,13 @@
+# Variance Event CLI
+
+A simple command-line tool to test the Variance (formerly Intrinsic) Go client E2E
+
+## Usage
+
+```
+go run cmd/create_event_async/main.go \
+  --event-type $EVENT_TYPE \
+  --api-key $API_KEY \
+  --base-url https://intrinsicapi.com \
+  --idempotency-key $OPTIONAL_IDEMPOTENCY_KEY
+```

--- a/cmd/create_event_async/main.go
+++ b/cmd/create_event_async/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/intrinsic-org/intrinsic-go/events"
+	"github.com/intrinsic-org/intrinsic-go/option"
+)
+
+func main() {
+	// Define command line flags
+	baseURL := flag.String("base-url", "", "Base URL for the API")
+	eventTypeName := flag.String("event-type", "", "The type of event being created")
+	dataJson := flag.String("data", "", "JSON file containing event data")
+	apiKey := flag.String("api-key", "", "API key for authentication")
+	idempotencyKey := flag.String("idempotency-key", "", "Idempotency key for the request")
+	flag.Parse()
+
+	if *baseURL == "" {
+		log.Fatal("--base-url is required")
+	}
+
+	if *eventTypeName == "" {
+		log.Fatal("--event-type is required")
+	}
+
+	// Parse event data from JSON string if provided, otherwise use empty object
+	var eventData map[string]interface{}
+	if *dataJson != "" {
+		if err := json.Unmarshal([]byte(*dataJson), &eventData); err != nil {
+			log.Fatalf("Failed to parse JSON data: %v", err)
+		}
+	} else {
+		eventData = make(map[string]interface{})
+	}
+
+	// Create options for the client
+	var opts []option.RequestOption
+	opts = append(opts, option.WithBaseURL(*baseURL))
+
+	// Add API key if provided
+	if *apiKey != "" {
+		opts = append(opts, option.WithAPIKey(*apiKey))
+	}
+
+	// Create a client with the options
+	client := events.NewClient(opts...)
+
+	// Add idempotency key if provided
+	if *idempotencyKey != "" {
+		headers := make(http.Header)
+		headers.Set("X-Idempotency-Key", *idempotencyKey)
+		opts = append(opts, option.WithHTTPHeader(headers))
+	}
+
+	// Create the event
+	ctx := context.Background()
+	resp, err := client.CreateEventAsync(ctx, *eventTypeName, eventData, opts...)
+	if err != nil {
+		log.Fatalf("Failed to create event: %v", err)
+	}
+
+	// Print the response
+	prettyResp, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		log.Fatalf("Failed to format response: %v", err)
+	}
+	fmt.Printf("Event created successfully:\n%s\n", string(prettyResp))
+}

--- a/core/retrier.go
+++ b/core/retrier.go
@@ -130,7 +130,6 @@ func (r *Retrier) run(
 func (r *Retrier) shouldRetry(response *http.Response) bool {
 	return response.StatusCode == http.StatusTooManyRequests ||
 		response.StatusCode == http.StatusRequestTimeout ||
-		response.StatusCode == http.StatusConflict ||
 		response.StatusCode >= http.StatusInternalServerError
 }
 

--- a/errors.go
+++ b/errors.go
@@ -4,6 +4,7 @@ package intrinsic
 
 import (
 	json "encoding/json"
+
 	core "github.com/intrinsic-org/intrinsic-go/core"
 )
 
@@ -97,4 +98,27 @@ func (n *NotFoundError) MarshalJSON() ([]byte, error) {
 
 func (n *NotFoundError) Unwrap() error {
 	return n.APIError
+}
+
+type ConflictError struct {
+	*core.APIError
+	Body *ErrorSchema
+}
+
+func (c *ConflictError) UnmarshalJSON(data []byte) error {
+	var body *ErrorSchema
+	if err := json.Unmarshal(data, &body); err != nil {
+		return err
+	}
+	c.StatusCode = 409
+	c.Body = body
+	return nil
+}
+
+func (c *ConflictError) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.Body)
+}
+
+func (c *ConflictError) Unwrap() error {
+	return c.APIError
 }

--- a/events/client.go
+++ b/events/client.go
@@ -8,11 +8,12 @@ import (
 	json "encoding/json"
 	errors "errors"
 	fmt "fmt"
+	io "io"
+	http "net/http"
+
 	intrinsicgo "github.com/intrinsic-org/intrinsic-go"
 	core "github.com/intrinsic-org/intrinsic-go/core"
 	option "github.com/intrinsic-org/intrinsic-go/option"
-	io "io"
-	http "net/http"
 )
 
 type Client struct {
@@ -160,6 +161,13 @@ func (c *Client) CreateEventAsync(
 			return value
 		case 404:
 			value := new(intrinsicgo.NotFoundError)
+			value.APIError = apiError
+			if err := decoder.Decode(value); err != nil {
+				return apiError
+			}
+			return value
+		case 409:
+			value := new(intrinsicgo.ConflictError)
 			value.APIError = apiError
 			if err := decoder.Decode(value); err != nil {
 				return apiError


### PR DESCRIPTION
```
❯ go run cmd/create_event_async/main.go \
  --event-type [REDACTED] \
  --api-key [REDACTED] \
  --base-url https://staging.intrinsicapi.com \
  --idempotency-key test-test
2025/04/24 10:25:30 Failed to create event: 409: {"error":{"type":"duplicate_request","message":"Duplicate event for event type: garfield_classifier, idempotency key: test-test","code":"409"}}
exit status 1
```